### PR TITLE
added props.value to initialState of Picker component 

### DIFF
--- a/Components/Picker/Picker.js
+++ b/Components/Picker/Picker.js
@@ -8,7 +8,13 @@ export default class JigsawPicker extends PureComponent {
   constructor (props) {
     super(props)
     this.state = {
-      pickerValue: null
+      pickerValue: props.value
+    }
+  }
+
+  componentWillReceiveProps(nextProps){
+    if (nextProps.value !== this.props.value) {
+      this.setState({ pickerValue: nextProps.value })
     }
   }
 


### PR DESCRIPTION
This fixes a bug I had with the Picker on IOS.
When pressing OK without changing the selected value, pickerValue in the state remained null.
This was because the component didn't update when only pressing OK.
Now the given value in the properties of the component will be set in the state.